### PR TITLE
Develop

### DIFF
--- a/.travis.maven.settings.xml
+++ b/.travis.maven.settings.xml
@@ -1,0 +1,35 @@
+<settings>
+    <profiles>
+        <profile>
+            <id>sonatype-oss-release</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <gpg.keyname>${env.GPG_ID}</gpg.keyname>
+                <passphraseServerId>${gpg.keyname}</passphraseServerId>
+            </properties>
+        </profile>
+    </profiles>
+    <servers>
+        <server>
+            <id>${env.GPG_ID}</id>
+            <passphrase>${env.GPG_PASSPHRASE}</passphrase>
+        </server>
+        <server>
+            <id>github</id>
+            <username>${env.GITHUB_USERNAME}</username>
+            <password>${env.GITHUB_PASSWORD}</password>
+        </server>
+        <server>
+            <id>sonatype-nexus-snapshots</id>
+            <username>${env.SONATYPE_USERNAME}</username>
+            <password>${env.SONATYPE_PASSWORD}</password>
+        </server>
+        <server>
+            <id>sonatype-nexus-staging</id>
+            <username>${env.SONATYPE_USERNAME}</username>
+            <password>${env.SONATYPE_PASSWORD}</password>
+        </server>
+    </servers>
+</settings>

--- a/.travis.maven.settings.xml
+++ b/.travis.maven.settings.xml
@@ -9,6 +9,27 @@
                 <gpg.keyname>${env.GPG_ID}</gpg.keyname>
                 <passphraseServerId>${gpg.keyname}</passphraseServerId>
             </properties>
+            <repositories>
+                <repository>
+                    <releases>
+                        <enabled>false</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                    <id>sonatype-nexus-snapshots</id>
+                    <name>Sonatype Nexus Snapshots</name>
+                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+                </repository>
+                <repository>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                    <id>central</id>
+                    <name>Central Repository</name>
+                    <url>https://repo.maven.apache.org/maven2</url>
+                </repository>
+            </repositories>
         </profile>
     </profiles>
     <servers>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: java
 jdk:
   - openjdk8
-cache:
-  directories:
-    - "$HOME/.m2"
+#cache:
+#  directories:
+#    - "$HOME/.m2"
 before_install:
   - echo $GPG_SECRET_KEYS | base64 --decode | gpg --import
   - echo $GPG_OWNERTRUST | base64 --decode | gpg --import-ownertrust

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 install:
   - mvn -s .travis.maven.settings.xml -version -B
 script:
-  - mvn -s .travis.maven.settings.xml clean install deploy -P sonatype-oss-release
+  - mvn -s .travis.maven.settings.xml clean install -U deploy -P sonatype-oss-release
 
 # Send notification to Slack
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
 install:
   - mvn -s .travis.maven.settings.xml -version -B
 script:
+  - mvn -s .travis.maven.settings.xml test
   - mvn -s .travis.maven.settings.xml clean install -U deploy -P sonatype-oss-release
 
 # Send notification to Slack

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,18 @@
 language: java
 jdk:
   - openjdk8
-#cache:
-#  directories:
-#    - "$HOME/.m2"
+cache:
+  directories:
+    - "$HOME/.m2"
 before_install:
   - echo $GPG_SECRET_KEYS | base64 --decode | gpg --import
   - echo $GPG_OWNERTRUST | base64 --decode | gpg --import-ownertrust
 install:
   - mvn -s .travis.maven.settings.xml -version -B
 script:
-  - mvn -s .travis.maven.settings.xml test
-  - mvn -s .travis.maven.settings.xml clean install -U deploy -P sonatype-oss-release
+#  - mvn -s .travis.maven.settings.xml test
+#  - mvn -s .travis.maven.settings.xml clean install -U deploy -P sonatype-oss-release
+  - mvn -s .travis.maven.settings.xml clean install deploy -P sonatype-oss-release
 
 # Send notification to Slack
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: java
+jdk:
+  - openjdk8
+cache:
+  directories:
+    - "$HOME/.m2"
+before_install:
+  - echo $GPG_SECRET_KEYS | base64 --decode | gpg --import
+  - echo $GPG_OWNERTRUST | base64 --decode | gpg --import-ownertrust
+install:
+  - mvn -s .travis.maven.settings.xml -version -B
+script:
+  - mvn -s .travis.maven.settings.xml clean install deploy -P sonatype-oss-release
+
+# Send notification to Slack
+notifications:
+  slack:
+    secure: "MrPZRn0zFIRrE2799AulKum/DnF9F21kVqmGGx9H1fl/dVwa50ToAcKJ38VtUgwoCpAqZ2KRrw1AenIvJit5QsH92hG183ELJqDT2eIhqFfc8teWXK+XfcE4rWmo7jsvBdP1oHzaog0Qqjjll/awakTs1JgwTA2mGmanC1zWPIGqKZD7qi3X/Y4KnHOFYyl6uJS8TxCQtthvyhIt0z3b2hUV3h9/AmKJ4oDDqs2NTUoCO1k9uThufjUsgV+jRuphzY3xQUzTMhDyqAKjb29iVDRt9ZBv7Cxuy7dJBNMIHRFl4fl2y2k1tdeViXhn44/tAcQRIz9rEEu1h8lGYV9osiZVCDl5m382ixkRM6iCiDmou/deJUK1Ws4R1FiJpgjdjB9gLRBhQHaqImyTl5mHfF2/lKOgbuPiPsMHZ6hB94/jS2ELQTnCT+mth42HTiYTGskVe6wmUhC/MeQ8b7WtSTnAxYmNwdu3W75ITqvYDQTc2JkIWCGDAh5fnPEkQ7k2UOAn7u6DbsEoxxEgfok/3TNGBBz2OGZMl+c95QjlNJxFcygpIa70xvRbzzGPlxeEZ4x4SJ02xDmfweNQ89GHgNfgwGDAZFRl5yaSPYsYLIfUr5oKcldxUCNLd2ZVLyy3ugLN3SV4AiBub2r1ZpWmfOpQxtJGl3vFSRQKX24pK2Q="

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/apiportal/abyss-exception.svg?branch=master)](https://travis-ci.org/apiportal/abyss-exception)
+
 # Abyss Exception
 
 This is the repository for Abyss Exception 

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
     <ciManagement>
         <system>Travis CI</system>
-        <url>https://travis-ci.org/apiportal-ci/abyss-exception</url>
+        <url>https://travis-ci.org/apiportal/abyss-exception</url>
     </ciManagement>
 
     <distributionManagement>

--- a/src/main/java/com/verapi/abyss/exception/AbyssApiException.java
+++ b/src/main/java/com/verapi/abyss/exception/AbyssApiException.java
@@ -1,22 +1,17 @@
 /*
+ * Copyright 2019 Verapi Inc
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *   http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing,
- *  * software distributed under the License is distributed on an
- *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  * KIND, either express or implied.  See the License for the
- *  * specific language governing permissions and limitations
- *  * under the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.verapi.abyss.exception;

--- a/src/main/java/com/verapi/abyss/exception/AbyssException.java
+++ b/src/main/java/com/verapi/abyss/exception/AbyssException.java
@@ -1,22 +1,17 @@
 /*
+ * Copyright 2019 Verapi Inc
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *   http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing,
- *  * software distributed under the License is distributed on an
- *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  * KIND, either express or implied.  See the License for the
- *  * specific language governing permissions and limitations
- *  * under the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.verapi.abyss.exception;

--- a/src/main/java/com/verapi/abyss/exception/ApiSchemaError.java
+++ b/src/main/java/com/verapi/abyss/exception/ApiSchemaError.java
@@ -1,22 +1,17 @@
 /*
+ * Copyright 2019 Verapi Inc
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *   http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing,
- *  * software distributed under the License is distributed on an
- *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  * KIND, either express or implied.  See the License for the
- *  * specific language governing permissions and limitations
- *  * under the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.verapi.abyss.exception;

--- a/src/main/java/com/verapi/abyss/exception/BadRequest400Exception.java
+++ b/src/main/java/com/verapi/abyss/exception/BadRequest400Exception.java
@@ -1,22 +1,17 @@
 /*
+ * Copyright 2019 Verapi Inc
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *   http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing,
- *  * software distributed under the License is distributed on an
- *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  * KIND, either express or implied.  See the License for the
- *  * specific language governing permissions and limitations
- *  * under the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.verapi.abyss.exception;

--- a/src/main/java/com/verapi/abyss/exception/Forbidden403Exception.java
+++ b/src/main/java/com/verapi/abyss/exception/Forbidden403Exception.java
@@ -1,22 +1,17 @@
 /*
+ * Copyright 2019 Verapi Inc
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *   http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing,
- *  * software distributed under the License is distributed on an
- *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  * KIND, either express or implied.  See the License for the
- *  * specific language governing permissions and limitations
- *  * under the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.verapi.abyss.exception;

--- a/src/main/java/com/verapi/abyss/exception/InternalServerError500Exception.java
+++ b/src/main/java/com/verapi/abyss/exception/InternalServerError500Exception.java
@@ -1,22 +1,17 @@
 /*
+ * Copyright 2019 Verapi Inc
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *   http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing,
- *  * software distributed under the License is distributed on an
- *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  * KIND, either express or implied.  See the License for the
- *  * specific language governing permissions and limitations
- *  * under the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.verapi.abyss.exception;

--- a/src/main/java/com/verapi/abyss/exception/MethodNotAllowed405Exception.java
+++ b/src/main/java/com/verapi/abyss/exception/MethodNotAllowed405Exception.java
@@ -1,22 +1,17 @@
 /*
+ * Copyright 2019 Verapi Inc
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *   http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing,
- *  * software distributed under the License is distributed on an
- *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  * KIND, either express or implied.  See the License for the
- *  * specific language governing permissions and limitations
- *  * under the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.verapi.abyss.exception;

--- a/src/main/java/com/verapi/abyss/exception/NoDataFoundException.java
+++ b/src/main/java/com/verapi/abyss/exception/NoDataFoundException.java
@@ -1,22 +1,17 @@
 /*
+ * Copyright 2019 Verapi Inc
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *   http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing,
- *  * software distributed under the License is distributed on an
- *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  * KIND, either express or implied.  See the License for the
- *  * specific language governing permissions and limitations
- *  * under the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.verapi.abyss.exception;

--- a/src/main/java/com/verapi/abyss/exception/NotFound404Exception.java
+++ b/src/main/java/com/verapi/abyss/exception/NotFound404Exception.java
@@ -1,22 +1,17 @@
 /*
+ * Copyright 2019 Verapi Inc
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *   http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing,
- *  * software distributed under the License is distributed on an
- *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  * KIND, either express or implied.  See the License for the
- *  * specific language governing permissions and limitations
- *  * under the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.verapi.abyss.exception;

--- a/src/main/java/com/verapi/abyss/exception/NotImplemented501Exception.java
+++ b/src/main/java/com/verapi/abyss/exception/NotImplemented501Exception.java
@@ -1,22 +1,17 @@
 /*
+ * Copyright 2019 Verapi Inc
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *   http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing,
- *  * software distributed under the License is distributed on an
- *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  * KIND, either express or implied.  See the License for the
- *  * specific language governing permissions and limitations
- *  * under the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.verapi.abyss.exception;

--- a/src/main/java/com/verapi/abyss/exception/TooManyRequests429Exception.java
+++ b/src/main/java/com/verapi/abyss/exception/TooManyRequests429Exception.java
@@ -1,22 +1,17 @@
 /*
+ * Copyright 2019 Verapi Inc
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *   http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing,
- *  * software distributed under the License is distributed on an
- *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  * KIND, either express or implied.  See the License for the
- *  * specific language governing permissions and limitations
- *  * under the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.verapi.abyss.exception;

--- a/src/main/java/com/verapi/abyss/exception/UnAuthorized401Exception.java
+++ b/src/main/java/com/verapi/abyss/exception/UnAuthorized401Exception.java
@@ -1,22 +1,17 @@
 /*
+ * Copyright 2019 Verapi Inc
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *   http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing,
- *  * software distributed under the License is distributed on an
- *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  * KIND, either express or implied.  See the License for the
- *  * specific language governing permissions and limitations
- *  * under the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.verapi.abyss.exception;

--- a/src/main/java/com/verapi/abyss/exception/UnProcessableEntity422Exception.java
+++ b/src/main/java/com/verapi/abyss/exception/UnProcessableEntity422Exception.java
@@ -1,22 +1,17 @@
 /*
+ * Copyright 2019 Verapi Inc
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *   http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing,
- *  * software distributed under the License is distributed on an
- *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  * KIND, either express or implied.  See the License for the
- *  * specific language governing permissions and limitations
- *  * under the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.verapi.abyss.exception;


### PR DESCRIPTION
- [x] ABYSSP-431 many changes to deploy into Github repo

    	unnecessary and inherited maven elements removed
    	github issue templates and related md files added
    	source code copyrights updated to Apache 2.0

- [x] ABYSSP-431 README.md file changes

    	maven site and scm publish plugin usage added

- [x] ABYSSP-431 pom.xml file changes

    	ciManagement and distributionManagement settings included

- [x] ABYSSP-431 license changes

    	copyright holder name included and license message typo fixed

- [x] ABYSSP-431 readme file changes

    	travis build status indicator added

- [x] ABYSSP-431 travis changes

    	.travis.yml added
    	.travis.maven.settings.xml added

- [x] ABYSSP-431 pom file changes

    	ciManagement declared

- [x] ABYSSP-431 travis changes

    	temporarily cancelled cache for .m2 directory to download fresh abyss-parent pom file from sonatype

- [x] ABYSSP-431 travis file changes

    	mvn -U option set to force a check for updated releases and snapshots on remote repositories

- [x] ABYSSP-431 travis file changes

    	mvn -s .travis.maven.settings.xml test script included

- [x] ABYSSP-431 travis.maven.settings.xml file changes

    	sonatype repositories declared
  
- [x] ABYSSP-431 travis.xml file changes

    	all changes rollbacked